### PR TITLE
Use IPADDR6_INIT() macro to set connecting IPv6 address

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -747,9 +747,8 @@ bool AsyncClient::connect(const IPAddress& ip, uint16_t port){
 
 #if LWIP_IPV6 && ESP_IDF_VERSION_MAJOR < 5
 bool AsyncClient::connect(const IPv6Address& ip, uint16_t port){
-    ip_addr_t addr;
-    addr.type = IPADDR_TYPE_V6;
-    memcpy(addr.u_addr.ip6.addr, static_cast<const uint32_t*>(ip), sizeof(uint32_t) * 4);
+    auto ipaddr = static_cast<const uint32_t*>(ip);
+    ip_addr_t addr = IPADDR6_INIT(ipaddr[0], ipaddr[1], ipaddr[2], ipaddr[3]);
 
     return _connect(addr, port);
 }


### PR DESCRIPTION
If LwIP is built with LWIP_IPV6_SCOPES, there is a 'zone' member in struct ip6_addr which was not being initialized correctly, leading to routing failures.

The tcp_connect() call would return ERR_RTE and we would completely fail to report that error. All the user would see is 'Connecting to MQTT...' over and over again.