### PR TITLE
Rollback #18 (assert failed: tcp_update_rcv_ann_wnd)

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -447,7 +447,7 @@ static esp_err_t _tcp_write(tcp_pcb * pcb, int8_t closed_slot, const char* data,
 static err_t _tcp_recved_api(struct tcpip_api_call_data *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = ERR_CONN;
-    if(msg->closed_slot != INVALID_CLOSED_SLOT && !_closed_slots[msg->closed_slot]) {
+    if(msg->closed_slot == INVALID_CLOSED_SLOT || !_closed_slots[msg->closed_slot]) {
         msg->err = 0;
         tcp_recved(msg->pcb, msg->received);
     }


### PR DESCRIPTION
This PR is a rollback of the changes merged in https://github.com/mathieucarbou/AsyncTCP/pull/18, which were done following some testing showing they fixed the issues raised in:

- https://github.com/mathieucarbou/AsyncTCP/issues/14
- https://github.com/mathieucarbou/AsyncTCP/issues/23
- https://github.com/tbnobody/OpenDTU/issues/2180

As it turns out in issue #23, it is still there.

The issue was easily reproductible by adding a delay as @mikeg0 pointed out in #14 

```c++
    // Route for root / web page
    server.on("/", HTTP_GET, [](AsyncWebServerRequest *request)
    {
        digitalWrite(networkLedPin, HIGH);

        request->send(SPIFFS, "/index.html", "text/html", false);

        delay(500);
        digitalWrite(networkLedPin, LOW);
    });
```

After some local testing, I am not able to reproduce it with the following code:

```c++
  // Issue #14: assert failed: tcp_update_rcv_ann_wnd (needs help to test fix)
  // > curl -v http://192.168.4.1/issue-14
  pinMode(4, OUTPUT);
  server.on("/issue-14", HTTP_GET, [](AsyncWebServerRequest* request) {
    digitalWrite(4, HIGH);
    request->send(LittleFS, "/index.txt", "text/pain");
    delay(500);
    digitalWrite(4, LOW);
  });
```

(https://github.com/mathieucarbou/ESPAsyncWebServer/blob/main/examples/SimpleServer/SimpleServer.ino#L327-L335)

**So what changed ?**

With the introduction of middleware, the response is NOT ANYMORE sent over the network when `send()` is called. Instead, the response is kept in memory until the middleware chain finished. At the end, the response (or a new one if a middleware replaced it) is sent, so the sending is done from the internal ESpAsyncWS code.

So even if we can have some delays or slowdown in the async_tcp callback prior to the real sending on the network, while processing the request, **it not now impossible to introduce some delays after the sending on the network is done and before returning from the callback.**

I tested by introducing some delay in the ESPAsyncWS code after the request is sent over the network, and in fact, the problem appears.

My hypothesis is that the client code should return ASAP after the sending over the network (tcp operation), maybe to let the asynctcp code read the ack or whatever, which it could not do if a delay is introduced.

**Conclusions**

- The issue seems to be caused by the introduction of delay (or yield to a more priority task ?) after send() and before returning
- With the middleware redesign, this situation becomes impossible since the response is sent once the handler / middleware chain is finished