### PR TITLE
Coalesce poll events on queue eviction

### DIFF
--- a/examples/Client/Client.ino
+++ b/examples/Client/Client.ino
@@ -45,7 +45,7 @@ void makeRequest() {
     });
 
     client->onData([](void* arg, AsyncClient* client, void* data, size_t len) {
-      // Serial.printf("** data received by client: %" PRIu16 ": len=%u\n", client->localPort(), len);
+      Serial.printf("** data received by client: %" PRIu16 ": len=%u\n", client->localPort(), len);
     });
 
     client->write("GET /README.md HTTP/1.1\r\nHost: " HOST "\r\nUser-Agent: ESP\r\nConnection: close\r\n\r\n");

--- a/examples/Client/Client.ino
+++ b/examples/Client/Client.ino
@@ -2,14 +2,14 @@
 #include <AsyncTCP.h>
 #include <WiFi.h>
 
-// #define HOST "homeassistant.local"
-// #define PORT 8123
-
-// #define HOST "www.google.com"
-// #define PORT 80
-
+// Run a server at the root of the project with: 
+// > python3 -m http.server 3333
+// Now you can open a browser and test it works by visiting http://192.168.125.122:3333/ or http://192.168.125.122:3333/README.md
 #define HOST "192.168.125.122"
-#define PORT 4000
+#define PORT 3333
+
+// WiFi SSID to connect to
+#define WIFI_SSID "IoT"
 
 // 16 slots on esp32 (CONFIG_LWIP_MAX_ACTIVE_TCP)
 #define MAX_CLIENTS CONFIG_LWIP_MAX_ACTIVE_TCP
@@ -48,7 +48,7 @@ void makeRequest() {
       // Serial.printf("** data received by client: %" PRIu16 ": len=%u\n", client->localPort(), len);
     });
 
-    client->write("GET / HTTP/1.1\r\nHost: " HOST "\r\nUser-Agent: ESP\r\nConnection: close\r\n\r\n");
+    client->write("GET /README.md HTTP/1.1\r\nHost: " HOST "\r\nUser-Agent: ESP\r\nConnection: close\r\n\r\n");
   });
 
   if (client->connect(HOST, PORT)) {
@@ -63,7 +63,7 @@ void setup() {
     continue;
 
   WiFi.mode(WIFI_STA);
-  WiFi.begin("IoT");
+  WiFi.begin(WIFI_SSID);
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);
     Serial.print(".");

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -65,7 +65,7 @@ extern "C" {
   TCP poll interval is specified in terms of the TCP coarse timer interval, which is called twice a second
   https://github.com/espressif/esp-lwip/blob/2acf959a2bb559313cd2bf9306c24612ba3d0e19/src/core/tcp.c#L1895
 */
-#define CONFIG_ASYNC_TCP_POLL_TIMER   1
+#define CONFIG_ASYNC_TCP_POLL_TIMER 1
 
 /*
  * TCP/IP Event Task
@@ -179,9 +179,9 @@ static inline bool _get_async_event(lwip_event_packet_t** e) {
     todo: implement some kind of fair dequeing or (better) simply punish user for a bad designed callbacks by resetting hog connections
   */
   lwip_event_packet_t* next_pkt = NULL;
-  while (xQueuePeek(_async_queue, &next_pkt, 0) == pdPASS){
-    if (next_pkt->arg == (*e)->arg && next_pkt->event == LWIP_TCP_POLL){
-      if (xQueueReceive(_async_queue, &next_pkt, 0) == pdPASS){
+  while (xQueuePeek(_async_queue, &next_pkt, 0) == pdPASS) {
+    if (next_pkt->arg == (*e)->arg && next_pkt->event == LWIP_TCP_POLL) {
+      if (xQueueReceive(_async_queue, &next_pkt, 0) == pdPASS) {
         free(next_pkt);
         next_pkt = NULL;
         log_d("coalescing polls, network congestion or async callbacks might be too slow!");
@@ -225,7 +225,7 @@ static bool _remove_events_with_arg(void* arg) {
       free(first_packet);
       first_packet = NULL;
 
-    // try to return first packet to the back of the queue
+      // try to return first packet to the back of the queue
     } else if (xQueueSend(_async_queue, &first_packet, 0) != pdPASS) {
       // we can't wait here if queue is full, because this call has been done from the only consumer task of this queue
       // otherwise it would deadlock, we have to discard the event
@@ -374,7 +374,7 @@ static int8_t _tcp_connected(void* arg, tcp_pcb* pcb, int8_t err) {
 
 static int8_t _tcp_poll(void* arg, struct tcp_pcb* pcb) {
   // throttle polling events queing when event queue is getting filled up, let it handle _onack's
-  //log_d("qs:%u", uxQueueMessagesWaiting(_async_queue));
+  // log_d("qs:%u", uxQueueMessagesWaiting(_async_queue));
   if (uxQueueMessagesWaiting(_async_queue) > (rand() % CONFIG_ASYNC_TCP_QUEUE_SIZE / 2 + CONFIG_ASYNC_TCP_QUEUE_SIZE / 4)) {
     log_d("throttling");
     return ERR_OK;

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -48,13 +48,16 @@ extern "C" {
   #include <semphr.h>
 }
   #define CONFIG_ASYNC_TCP_RUNNING_CORE -1 // any available core
-  #define CONFIG_ASYNC_TCP_USE_WDT      0
 #endif
 
 // If core is not defined, then we are running in Arduino or PIO
 #ifndef CONFIG_ASYNC_TCP_RUNNING_CORE
   #define CONFIG_ASYNC_TCP_RUNNING_CORE -1 // any available core
-  #define CONFIG_ASYNC_TCP_USE_WDT      1  // if enabled, adds between 33us and 200us per event
+#endif
+
+// guard AsyncTCP task with watchdog
+#ifndef CONFIG_ASYNC_TCP_USE_WDT
+  #define CONFIG_ASYNC_TCP_USE_WDT      1
 #endif
 
 #ifndef CONFIG_ASYNC_TCP_STACK_SIZE

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -57,7 +57,7 @@ extern "C" {
 
 // guard AsyncTCP task with watchdog
 #ifndef CONFIG_ASYNC_TCP_USE_WDT
-  #define CONFIG_ASYNC_TCP_USE_WDT      1
+  #define CONFIG_ASYNC_TCP_USE_WDT 1
 #endif
 
 #ifndef CONFIG_ASYNC_TCP_STACK_SIZE
@@ -111,12 +111,12 @@ class AsyncClient {
     bool connect(const char* host, uint16_t port);
     /**
      * @brief close connection
-     * 
+     *
      * @param now - ignored
      */
     void close(bool now = false);
     // same as close()
-    void stop(){ close(false); };
+    void stop() { close(false); };
     int8_t abort();
     bool free();
 
@@ -134,17 +134,17 @@ class AsyncClient {
         it is enforced in https://github.com/espressif/esp-lwip/blob/0606eed9d8b98a797514fdf6eabb4daf1c8c8cd9/src/core/tcp_out.c#L422C5-L422C30
         if LWIP_NETIF_TX_SINGLE_PBUF is set, and it is set indeed in IDF
         https://github.com/espressif/esp-idf/blob/a0f798cfc4bbd624aab52b2c194d219e242d80c1/components/lwip/port/include/lwipopts.h#L744
-     * 
-     * @param data 
-     * @param size 
-     * @param apiflags 
+     *
+     * @param data
+     * @param size
+     * @param apiflags
      * @return size_t amount of data that has been copied
      */
     size_t add(const char* data, size_t size, uint8_t apiflags = ASYNC_WRITE_FLAG_COPY);
 
     /**
      * @brief send data previously add()'ed
-     * 
+     *
      * @return true on success
      * @return false on error
      */
@@ -154,22 +154,22 @@ class AsyncClient {
      * @brief add and enqueue data for sending
      * @note it is same as add() + send()
      * @note only make sense when canSend() == true
-     * 
-     * @param data 
-     * @param size 
-     * @param apiflags 
-     * @return size_t 
+     *
+     * @param data
+     * @param size
+     * @param apiflags
+     * @return size_t
      */
     size_t write(const char* data, size_t size, uint8_t apiflags = ASYNC_WRITE_FLAG_COPY);
 
     /**
      * @brief add and enque data for sending
      * @note treats data as null-terminated string
-     * 
-     * @param data 
-     * @return size_t 
+     *
+     * @param data
+     * @return size_t
      */
-    size_t write(const char* data){ return data == NULL ? 0 : write(data, strlen(data)); };
+    size_t write(const char* data) { return data == NULL ? 0 : write(data, strlen(data)); };
 
     uint8_t state();
     bool connecting();

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -109,34 +109,86 @@ class AsyncClient {
     bool connect(const IPv6Address& ip, uint16_t port);
 #endif
     bool connect(const char* host, uint16_t port);
+    /**
+     * @brief close connection
+     * 
+     * @param now - ignored
+     */
     void close(bool now = false);
-    void stop();
+    // same as close()
+    void stop(){ close(false); };
     int8_t abort();
     bool free();
 
-    bool canSend();                                                                      // ack is not pending
-    size_t space();                                                                      // space available in the TCP window
-    size_t add(const char* data, size_t size, uint8_t apiflags = ASYNC_WRITE_FLAG_COPY); // add for sending
-    bool send();                                                                         // send all data added with the method above
+    // ack is not pending
+    bool canSend();
+    // TCP buffer space available
+    size_t space();
 
-    // write equals add()+send()
-    size_t write(const char* data);
-    size_t write(const char* data, size_t size, uint8_t apiflags = ASYNC_WRITE_FLAG_COPY); // only when canSend() == true
+    /**
+     * @brief add data to be send (but do not send yet)
+     * @note add() would call lwip's tcp_write()
+        By default apiflags=ASYNC_WRITE_FLAG_COPY
+        You could try to use apiflags with this flag unset to pass data by reference and avoid copy to socket buffer,
+        but looks like it does not work for Arduino's lwip in ESP32/IDF at least
+        it is enforced in https://github.com/espressif/esp-lwip/blob/0606eed9d8b98a797514fdf6eabb4daf1c8c8cd9/src/core/tcp_out.c#L422C5-L422C30
+        if LWIP_NETIF_TX_SINGLE_PBUF is set, and it is set indeed in IDF
+        https://github.com/espressif/esp-idf/blob/a0f798cfc4bbd624aab52b2c194d219e242d80c1/components/lwip/port/include/lwipopts.h#L744
+     * 
+     * @param data 
+     * @param size 
+     * @param apiflags 
+     * @return size_t amount of data that has been copied
+     */
+    size_t add(const char* data, size_t size, uint8_t apiflags = ASYNC_WRITE_FLAG_COPY);
+
+    /**
+     * @brief send data previously add()'ed
+     * 
+     * @return true on success
+     * @return false on error
+     */
+    bool send();
+
+    /**
+     * @brief add and enqueue data for sending
+     * @note it is same as add() + send()
+     * @note only make sense when canSend() == true
+     * 
+     * @param data 
+     * @param size 
+     * @param apiflags 
+     * @return size_t 
+     */
+    size_t write(const char* data, size_t size, uint8_t apiflags = ASYNC_WRITE_FLAG_COPY);
+
+    /**
+     * @brief add and enque data for sending
+     * @note treats data as null-terminated string
+     * 
+     * @param data 
+     * @return size_t 
+     */
+    size_t write(const char* data){ return data == NULL ? 0 : write(data, strlen(data)); };
 
     uint8_t state();
     bool connecting();
     bool connected();
     bool disconnecting();
     bool disconnected();
-    bool freeable(); // disconnected or disconnecting
+
+    // disconnected or disconnecting
+    bool freeable();
 
     uint16_t getMss();
 
     uint32_t getRxTimeout();
-    void setRxTimeout(uint32_t timeout); // no RX data timeout for the connection in seconds
+    // no RX data timeout for the connection in seconds
+    void setRxTimeout(uint32_t timeout);
 
     uint32_t getAckTimeout();
-    void setAckTimeout(uint32_t timeout); // no ACK timeout for the last sent packet in milliseconds
+    // no ACK timeout for the last sent packet in milliseconds
+    void setAckTimeout(uint32_t timeout);
 
     void setNoDelay(bool nodelay);
     bool getNoDelay();
@@ -165,23 +217,34 @@ class AsyncClient {
     IPAddress localIP();
     uint16_t localPort();
 
-    void onConnect(AcConnectHandler cb, void* arg = 0);    // on successful connect
-    void onDisconnect(AcConnectHandler cb, void* arg = 0); // disconnected
-    void onAck(AcAckHandler cb, void* arg = 0);            // ack received
-    void onError(AcErrorHandler cb, void* arg = 0);        // unsuccessful connect or error
-    void onData(AcDataHandler cb, void* arg = 0);          // data received (called if onPacket is not used)
-    void onPacket(AcPacketHandler cb, void* arg = 0);      // data received
-    void onTimeout(AcTimeoutHandler cb, void* arg = 0);    // ack timeout
-    void onPoll(AcConnectHandler cb, void* arg = 0);       // every 125ms when connected
+    // set callback - on successful connect
+    void onConnect(AcConnectHandler cb, void* arg = 0);
+    // set callback - disconnected
+    void onDisconnect(AcConnectHandler cb, void* arg = 0);
+    // set callback - ack received
+    void onAck(AcAckHandler cb, void* arg = 0);
+    // set callback - unsuccessful connect or error
+    void onError(AcErrorHandler cb, void* arg = 0);
+    // set callback - data received (called if onPacket is not used)
+    void onData(AcDataHandler cb, void* arg = 0);
+    // set callback - data received
+    void onPacket(AcPacketHandler cb, void* arg = 0);
+    // set callback - ack timeout
+    void onTimeout(AcTimeoutHandler cb, void* arg = 0);
+    // set callback - every 125ms when connected
+    void onPoll(AcConnectHandler cb, void* arg = 0);
 
-    void ackPacket(struct pbuf* pb);      // ack pbuf from onPacket
-    size_t ack(size_t len);               // ack data that you have not acked using the method below
-    void ackLater() { _ack_pcb = false; } // will not ack the current packet. Call from onData
+    // ack pbuf from onPacket
+    void ackPacket(struct pbuf* pb);
+    // ack data that you have not acked using the method below
+    size_t ack(size_t len);
+    // will not ack the current packet. Call from onData
+    void ackLater() { _ack_pcb = false; }
 
     const char* errorToString(int8_t error);
     const char* stateToString();
 
-    // Do not use any of the functions below!
+    // internal callbacks - Do NOT call any of the functions below in user code!
     static int8_t _s_poll(void* arg, struct tcp_pcb* tpcb);
     static int8_t _s_recv(void* arg, struct tcp_pcb* tpcb, struct pbuf* pb, int8_t err);
     static int8_t _s_fin(void* arg, struct tcp_pcb* tpcb, int8_t err);


### PR DESCRIPTION
Coalesce poll events on queue eviction

Refer: mathieucarbou/ESPAsyncWebServer#165

Try to coalesce two (or more) consecutive poll events into one.
This usually happens with poor implemented user-callbacks that are runs too long and makes poll events to stack in the queue if consecutive user callback for a same connection runs longer that poll time then it will fill the queue with events until it deadlocks.
This is a workaround to mitigate such poor designs and won't let other events/connections to starve the task time.
It won't be effective if user would run multiple simultaneous long running callbacks due to message interleaving.

**queue deadlock and congestion avoidance**

 - do not let `_remove_events_with_arg()` call to block on queue pertubation, otherwise it could deadlock

 - in any case do not block on adding LWIP_TCP_POLL event to the queue, it does not make much sense anyway
   due to poll events are repetitive

 - `_get_async_event()` will discard LWIP_TCP_POLL events when q gets filled up
   this will work in combination with throttling poll events when adding to the queue
   Poor designed apps and multiple parallel connections could flood the queue with interleaved poll events
   that can't be properly throttled or coalesced. So we can discard it in the eviction task after coalescing
   It will work in this way:
    - queue is up to 1/4 full - all events are entering the queue and serviced
    - queue is from 1/4 and up to 3/4 full - new poll events are throttled on enqueue with linear-increasing probability
    - queue is from 3/4 up to full top - all new poll events are ignored on enqueue and existing poll events
      already in the queue are discarded on eviction with linear-increasing probability giving away priority for all other
      events to be serviced. It is expected that on a new poll timer connection polls could reenter the queue
