### PR TITLE
Remove libCompatMode from library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -22,9 +22,6 @@
     "espressif32",
     "libretiny"
   ],
-  "build": {
-    "libCompatMode": 2
-  },
   "export": {
     "include": [
       "examples",


### PR DESCRIPTION
Specifying libCompatMode in library.json prevents projects from overriding the library compatibility mode as needed. This prevents the library from being used in builds where Arduino is a component to ESP-IDF.

Although an issue has not been raised for this library specifically, if merged, this would resolve the same issue discussed here: https://github.com/mathieucarbou/ESPAsyncWebServer/issues/188